### PR TITLE
Create hook for related models

### DIFF
--- a/lib/read-only.js
+++ b/lib/read-only.js
@@ -106,6 +106,13 @@ module.exports = Model => {
           }
           return next()
         })
+        
+        Model.beforeRemote(`prototype.__create__${relationName}`, (ctx, modelInstance, next) => {
+          if (typeof AffectedModel.stripReadOnlyProperties === 'function') {
+            return AffectedModel.stripReadOnlyProperties(modelName, ctx, modelInstance, next)
+          }
+          return next()
+        })
       }
     })
 


### PR DESCRIPTION
Related model's hooks contains only `prototype.__updateById__${relationName}` method.
But also `prototype.__create__${relationName}` should be exists to handle routes like `POST /product/{id}/reviews`.