### PR TITLE
fix: ReadOnly for belongsTo relations

### DIFF
--- a/lib/read-only.js
+++ b/lib/read-only.js
@@ -95,11 +95,10 @@ module.exports = Model => {
     // Handle updates via relationship.
     Object.keys(Model.definition.settings.relations).forEach(relationName => {
       const relation = Model.definition.settings.relations[relationName]
+      const modelName = relation.model
+      const AffectedModel = Model.app.loopback.getModel(modelName)
 
       if (relation.type.startsWith('has')) {
-        const modelName = relation.model
-        const AffectedModel = Model.app.loopback.getModel(modelName)
-
         Model.beforeRemote(`prototype.__updateById__${relationName}`, (ctx, modelInstance, next) => {
           if (typeof AffectedModel.stripReadOnlyProperties === 'function') {
             return AffectedModel.stripReadOnlyProperties(modelName, ctx, modelInstance, next)
@@ -107,6 +106,43 @@ module.exports = Model => {
           return next()
         })
       }
+      if (relation.type.startsWith('belongs')) {
+        const affectedRelations = AffectedModel.definition.settings.relations
+        const affectedRelName = Object.keys(affectedRelations).find(name =>
+          affectedRelations[name].model === Model.modelName
+        )
+
+        if (affectedRelName) {
+          AffectedModel.beforeRemote(`prototype.__create__${affectedRelName}`,
+            (ctx, modelInstance, next) => {
+              if (typeof Model.stripReadOnlyProperties === 'function') {
+                return Model.stripReadOnlyProperties(
+                  Model.modelName,
+                  ctx,
+                  modelInstance,
+                  next
+                )
+              }
+              return next()
+            }
+          )
+
+          AffectedModel.beforeRemote(`prototype.__updateById__${affectedRelName}`,
+            (ctx, modelInstance, next) => {
+              if (typeof Model.stripReadOnlyProperties === 'function') {
+                return Model.stripReadOnlyProperties(
+                  Model.modelName,
+                  ctx,
+                  modelInstance,
+                  next
+                )
+              }
+              return next()
+            }
+          )
+        }
+      }
+
     })
 
   })


### PR DESCRIPTION
I have a Model with ReadOnly properties which belongs to a User. Due to ACL-ruling I need to create my model from the User REST-paths. 
Before this PR, the read only mixin was not preventing me from editing the read only properties in this way.